### PR TITLE
Use inventory OS information instead of parameters it in the HostManager methods

### DIFF
--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -382,7 +382,7 @@ class HostManager:
                 Exception: If the service cannot be controlled
         """
         testinfra_host = self.get_host(host)
-        ansible_command = 'win_service' if self.get_host_variables(host)['os_name']== 'windows' else 'service'
+        ansible_command = 'win_service' if self.get_host_variables(host)['os_name'] == 'windows' else 'service'
 
         result = testinfra_host.ansible(ansible_command, f"name={service} state={state}", check=False, become=become)
 
@@ -498,7 +498,7 @@ class HostManager:
 
         if self.get_host_variables(host)['os_name'] == 'windows':
             ansible_command = 'ansible.windows.win_stat'
-        else: 
+        else:
             ansible_command = 'stat'
 
         result = testinfra_host.ansible(ansible_command, f"path={path}", check=False, become=become)
@@ -507,4 +507,3 @@ class HostManager:
             raise Exception(f"Error getting stats of {path} on host {host}: {result}")
 
         return result
-    

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -13,6 +13,7 @@ from ansible.vars.manager import VariableManager
 
 
 class HostManager:
+
     """Remote host management interface.
 
     It allows to manage remote hosts using ansible inventory and testinfra framework.

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -159,7 +159,7 @@ class HostManager:
             src_path (str): Source path
             dest_path (str): Destination path
             remote_src (bool): If True, the file is assumed to live on the remote machine, not the controller.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool): Ignore errors
 
@@ -194,7 +194,7 @@ class HostManager:
         Args:
             host (str): Hostname
             path (str): File path
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool): Ignore errors
 
@@ -228,7 +228,7 @@ class HostManager:
             host (str): Hostname
             dest_path (str): Destination path
             filesystem (dict): File structure
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -274,7 +274,7 @@ class HostManager:
             host (str): Hostname
             file_path (str): File path
             recreate (bool, optional): Recreate file. Defaults to True.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -312,7 +312,7 @@ class HostManager:
         Args:
             host (str): Hostname
             file_path (str): File path
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -345,7 +345,7 @@ class HostManager:
             host (str): Hostname
             path (str): path for the file to create and modify
             content (str, bytes): content to write into the file
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -384,7 +384,7 @@ class HostManager:
             owner (str): owner of the file
             group (str): group of the file
             mode (str): mode of the file
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -427,7 +427,7 @@ class HostManager:
                 host (str): Hostname
                 service (str): Service name
                 state (str): Service state
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
                 ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -460,7 +460,7 @@ class HostManager:
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -495,7 +495,7 @@ class HostManager:
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -536,7 +536,7 @@ class HostManager:
             pattern (str): Restrict the files to be returned to those whose basenames match the pattern specified.
             recurse (bool): If target is a directory, recursively descend into the directory looking for files.
             use_regex (bool): If no, the patterns are file globs (shell), if yes, they are python regexes.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
@@ -572,7 +572,7 @@ class HostManager:
         Args:
             host (str): Hostname.
             path (str): The full path of the file/object to get the facts of.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+            become (bool): If no value is provided, it will take from the inventory. If there is no value,
             it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -350,7 +350,7 @@ class HostManager:
         tmp_file = tempfile.NamedTemporaryFile()
         with open(tmp_file.name, 'w+') as tmp:
             tmp.write(content)
-        
+
         ansible_command = 'win_copy' if self.get_host_variables(host)['os_name'] == 'windows' else 'copy'
 
         ansible_parameters = f"src={tmp_file.name} dest={path}"
@@ -497,8 +497,9 @@ class HostManager:
         testinfra_host = self.get_host(host)
 
         if self.get_host_variables(host)['os_name'] == 'windows':
-            ansible_command = 'ansible.windows.win_stat' 
-        else: ansible_command = 'stat'
+            ansible_command = 'ansible.windows.win_stat'
+        else: 
+            ansible_command = 'stat'
 
         result = testinfra_host.ansible(ansible_command, f"path={path}", check=False, become=become)
 
@@ -506,3 +507,4 @@ class HostManager:
             raise Exception(f"Error getting stats of {path} on host {host}: {result}")
 
         return result
+    

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -160,7 +160,7 @@ class HostManager:
             dest_path (str): Destination path
             remote_src (bool): If True, the file is assumed to live on the remote machine, not the controller.
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -194,7 +194,7 @@ class HostManager:
             host (str): Hostname
             path (str): File path
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -227,7 +227,7 @@ class HostManager:
             dest_path (str): Destination path
             filesystem (dict): File structure
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -272,7 +272,7 @@ class HostManager:
             file_path (str): File path
             recreate (bool, optional): Recreate file. Defaults to True.
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -309,7 +309,7 @@ class HostManager:
             host (str): Hostname
             file_path (str): File path
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -341,7 +341,7 @@ class HostManager:
             path (str): path for the file to create and modify
             content (str, bytes): content to write into the file
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -379,7 +379,7 @@ class HostManager:
             group (str): group of the file
             mode (str): mode of the file
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -421,7 +421,7 @@ class HostManager:
                 service (str): Service name
                 state (str): Service state
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
                 ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
             Returns:
@@ -453,7 +453,7 @@ class HostManager:
             host (str): Hostname
             cmd (str): Command to run
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -487,7 +487,7 @@ class HostManager:
             host (str): Hostname
             cmd (str): Command to run
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -527,7 +527,7 @@ class HostManager:
             recurse (bool): If target is a directory, recursively descend into the directory looking for files.
             use_regex (bool): If no, the patterns are file globs (shell), if yes, they are python regexes.
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -562,7 +562,7 @@ class HostManager:
             host (str): Hostname.
             path (str): The full path of the file/object to get the facts of.
             become (bool): If no value is provided, it will take from the inventory. If there is no value, 
-                           it will default to False.
+            it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -590,4 +590,3 @@ class HostManager:
             raise Exception(f"Error getting stats of {path} on host {host}: {result}")
 
         return result
-

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -159,8 +159,7 @@ class HostManager:
             src_path (str): Source path
             dest_path (str): Destination path
             remote_src (bool): If True, the file is assumed to live on the remote machine, not the controller.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -169,12 +168,7 @@ class HostManager:
         Raises:
             Exception: If the command execution fails
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_copy' if self.get_host_variables(host)['os_name'] == 'windows' else 'copy'
@@ -194,8 +188,7 @@ class HostManager:
         Args:
             host (str): Hostname
             path (str): File path
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -204,12 +197,7 @@ class HostManager:
         Raises:
             Exception: If the file cannot be read
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         result = testinfra_host.ansible("slurp", f"src={path}", check=False, become=become)
@@ -228,8 +216,7 @@ class HostManager:
             host (str): Hostname
             dest_path (str): Destination path
             filesystem (dict): File structure
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -238,12 +225,7 @@ class HostManager:
         Raises:
             Exception: If the command execution fails
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
 
@@ -274,8 +256,7 @@ class HostManager:
             host (str): Hostname
             file_path (str): File path
             recreate (bool, optional): Recreate file. Defaults to True.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -284,12 +265,7 @@ class HostManager:
         Raises:
             Exception: If the file cannot be truncated
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         result = None
@@ -312,8 +288,7 @@ class HostManager:
         Args:
             host (str): Hostname
             file_path (str): File path
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -322,12 +297,7 @@ class HostManager:
         Raises:
             Exception: If the file cannot be removed
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_file' if self.get_host_variables(host)['os_name'] == 'windows' else 'file'
@@ -345,8 +315,7 @@ class HostManager:
             host (str): Hostname
             path (str): path for the file to create and modify
             content (str, bytes): content to write into the file
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -355,12 +324,7 @@ class HostManager:
         Raises:
             Exception: If the file cannot be modified
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         tmp_file = tempfile.NamedTemporaryFile()
         with open(tmp_file.name, 'w+') as tmp:
@@ -384,8 +348,7 @@ class HostManager:
             owner (str): owner of the file
             group (str): group of the file
             mode (str): mode of the file
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -394,12 +357,7 @@ class HostManager:
         Raises:
             Exception: If the file cannot be created
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         tmp_file = tempfile.NamedTemporaryFile()
@@ -427,8 +385,7 @@ class HostManager:
                 host (str): Hostname
                 service (str): Service name
                 state (str): Service state
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+                become (bool): If no value is provided, it will take from the inventory.
                 ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
             Returns:
@@ -437,12 +394,7 @@ class HostManager:
             Raises:
                 Exception: If the service cannot be controlled
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_service' if self.get_host_variables(host)['os_name'] == 'windows' else 'service'
@@ -460,8 +412,7 @@ class HostManager:
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -470,12 +421,7 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_command' if self.get_host_variables(host)['os_name'] == 'windows' else 'command'
@@ -495,8 +441,7 @@ class HostManager:
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -505,12 +450,7 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
         rc = None
@@ -536,8 +476,7 @@ class HostManager:
             pattern (str): Restrict the files to be returned to those whose basenames match the pattern specified.
             recurse (bool): If target is a directory, recursively descend into the directory looking for files.
             use_regex (bool): If no, the patterns are file globs (shell), if yes, they are python regexes.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -546,12 +485,7 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         test_infra_host = self.get_host(host)
         ansible_command = 'win_find' if self.get_host_variables(host)['os_name'] == 'windows' else 'find'
@@ -572,8 +506,7 @@ class HostManager:
         Args:
             host (str): Hostname.
             path (str): The full path of the file/object to get the facts of.
-            become (bool): If no value is provided, it will take from the inventory. If there is no value,
-            it will default to False.
+            become (bool): If no value is provided, it will take from the inventory.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -582,12 +515,7 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run.
         """
-        if become is None:
-            if 'become' in self.get_host_variables(host):
-                become = self.get_host_variables(host)['become'].get('become', False)
-
-                if become in ['', None]:
-                    become = False
+        become = self.get_host_variables(host).get('become', False) if become is None else become
 
         testinfra_host = self.get_host(host)
 

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -170,10 +170,11 @@ class HostManager:
             Exception: If the command execution fails
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_copy' if self.get_host_variables(host)['os_name'] == 'windows' else 'copy'
@@ -204,10 +205,11 @@ class HostManager:
             Exception: If the file cannot be read
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         result = testinfra_host.ansible("slurp", f"src={path}", check=False, become=become)
@@ -237,10 +239,11 @@ class HostManager:
             Exception: If the command execution fails
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
 
@@ -282,10 +285,11 @@ class HostManager:
             Exception: If the file cannot be truncated
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         result = None
@@ -319,10 +323,11 @@ class HostManager:
             Exception: If the file cannot be removed
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_file' if self.get_host_variables(host)['os_name'] == 'windows' else 'file'
@@ -351,10 +356,11 @@ class HostManager:
             Exception: If the file cannot be modified
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         tmp_file = tempfile.NamedTemporaryFile()
         with open(tmp_file.name, 'w+') as tmp:
@@ -389,10 +395,11 @@ class HostManager:
             Exception: If the file cannot be created
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         tmp_file = tempfile.NamedTemporaryFile()
@@ -431,10 +438,11 @@ class HostManager:
                 Exception: If the service cannot be controlled
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_service' if self.get_host_variables(host)['os_name'] == 'windows' else 'service'
@@ -463,10 +471,11 @@ class HostManager:
             Exception: If the command cannot be run
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_command' if self.get_host_variables(host)['os_name'] == 'windows' else 'command'
@@ -497,10 +506,11 @@ class HostManager:
             Exception: If the command cannot be run
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
         rc = None
@@ -537,10 +547,11 @@ class HostManager:
             Exception: If the command cannot be run
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         test_infra_host = self.get_host(host)
         ansible_command = 'win_find' if self.get_host_variables(host)['os_name'] == 'windows' else 'find'
@@ -572,10 +583,11 @@ class HostManager:
             Exception: If the command cannot be run.
         """
         if become is None:
-            become = self.get_host_variables(host)['become'].get('become', False)
+            if 'become' in self.get_host_variables(host):
+                become = self.get_host_variables(host)['become'].get('become', False)
 
-            if become in ['', None]:
-                become = False
+                if become in ['', None]:
+                    become = False
 
         testinfra_host = self.get_host(host)
 

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -6,7 +6,6 @@ import tempfile
 import testinfra
 import base64
 import os
-import yaml
 from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
 from ansible.vars.manager import VariableManager

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -13,7 +13,6 @@ from ansible.vars.manager import VariableManager
 
 
 class HostManager:
-
     """Remote host management interface.
 
     It allows to manage remote hosts using ansible inventory and testinfra framework.
@@ -293,7 +292,6 @@ class HostManager:
         """
 
         testinfra_host = self.get_host(host)
-        
         ansible_command = 'win_file' if self.get_host_variables(host)['os_name'] == 'windows' else 'file'
         result = testinfra_host.ansible(ansible_command, f"path={file_path} state=absent", check=False, become=become)
 
@@ -498,8 +496,10 @@ class HostManager:
             Exception: If the command cannot be run.
         """
         testinfra_host = self.get_host(host)
-        
-        ansible_command = 'ansible.windows.win_stat' if self.get_host_variables(host)['os_name'] == 'windows' else 'stat'
+
+        if self.get_host_variables(host)['os_name'] == 'windows':
+            ansible_command = 'ansible.windows.win_stat' 
+        else: ansible_command = 'stat'
 
         result = testinfra_host.ansible(ansible_command, f"path={path}", check=False, become=become)
 

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -151,7 +151,7 @@ class HostManager:
         ansible_command = 'win_ping' if self.get_host_variables(host)['os_name'] == 'windows' else 'ping'
         return testinfra_host.ansible(ansible_command, check=False)['ping'] == 'pong'
 
-    def copy_file(self, host, src_path, dest_path, remote_src=False, become=False, ignore_errors=False):
+    def copy_file(self, host, src_path, dest_path, remote_src=False, become=None, ignore_errors=False):
         """Move from src_path to the desired location dest_path for the specified host.
 
         Args:
@@ -159,7 +159,8 @@ class HostManager:
             src_path (str): Source path
             dest_path (str): Destination path
             remote_src (bool): If True, the file is assumed to live on the remote machine, not the controller.
-            become (bool): Use sudo
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -168,6 +169,12 @@ class HostManager:
         Raises:
             Exception: If the command execution fails
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         ansible_command = 'win_copy' if self.get_host_variables(host)['os_name'] == 'windows' else 'copy'
         remote_source = 'yes' if remote_src else 'no'
@@ -180,13 +187,14 @@ class HostManager:
 
         return result
 
-    def get_file_content(self, host, path, become=False, ignore_errors=False):
+    def get_file_content(self, host, path, become=None, ignore_errors=False):
         """Read a file from the specified host.
 
         Args:
             host (str): Hostname
             path (str): File path
-            become (bool): Use sudo
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -195,6 +203,12 @@ class HostManager:
         Raises:
             Exception: If the file cannot be read
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         result = testinfra_host.ansible("slurp", f"src={path}", check=False, become=become)
 
@@ -203,7 +217,7 @@ class HostManager:
 
         return base64.b64decode(result['content']).decode('utf-8')
 
-    def synchronize_linux_directory(self, host, dest_path, src_path=None, filesystem=None, become=False,
+    def synchronize_linux_directory(self, host, dest_path, src_path=None, filesystem=None, become=None,
                                     ignore_errors=False):
         """Create a file structure on the specified host.
         Not supported on Windows.
@@ -212,7 +226,8 @@ class HostManager:
             host (str): Hostname
             dest_path (str): Destination path
             filesystem (dict): File structure
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -221,6 +236,12 @@ class HostManager:
         Raises:
             Exception: If the command execution fails
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
 
         ansible_command = 'synchronize'
@@ -243,14 +264,15 @@ class HostManager:
 
         return result
 
-    def truncate_file(self, host, file_path, recreate=True, become=False, ignore_errors=False):
+    def truncate_file(self, host, file_path, recreate=True, become=None, ignore_errors=False):
         """Truncate a file from the specified host.
 
         Args:
             host (str): Hostname
             file_path (str): File path
             recreate (bool, optional): Recreate file. Defaults to True.
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -259,6 +281,12 @@ class HostManager:
         Raises:
             Exception: If the file cannot be truncated
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         result = None
 
@@ -274,13 +302,14 @@ class HostManager:
 
         return result
 
-    def remove_file(self, host, file_path, become=False, ignore_errors=False):
+    def remove_file(self, host, file_path, become=None, ignore_errors=False):
         """Remove a file from the specified host.
 
         Args:
             host (str): Hostname
             file_path (str): File path
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -289,6 +318,11 @@ class HostManager:
         Raises:
             Exception: If the file cannot be removed
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
 
         testinfra_host = self.get_host(host)
         ansible_command = 'win_file' if self.get_host_variables(host)['os_name'] == 'windows' else 'file'
@@ -299,14 +333,15 @@ class HostManager:
 
         return result
 
-    def modify_file_content(self, host, path, content, become=False, ignore_errors=False):
+    def modify_file_content(self, host, path, content, become=None, ignore_errors=False):
         """Create a file with a specified content and copies it to a path.
 
         Args:
             host (str): Hostname
             path (str): path for the file to create and modify
             content (str, bytes): content to write into the file
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -315,6 +350,12 @@ class HostManager:
         Raises:
             Exception: If the file cannot be modified
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         tmp_file = tempfile.NamedTemporaryFile()
         with open(tmp_file.name, 'w+') as tmp:
             tmp.write(content)
@@ -326,7 +367,7 @@ class HostManager:
 
         return result
 
-    def create_file(self, host, path, content, directory=False, owner=None, group=None, mode=None, become=False,
+    def create_file(self, host, path, content, directory=False, owner=None, group=None, mode=None, become=None,
                     ignore_errors=False):
         """Create a file with a specified content and copies it to a path.
 
@@ -337,7 +378,8 @@ class HostManager:
             owner (str): owner of the file
             group (str): group of the file
             mode (str): mode of the file
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -346,6 +388,12 @@ class HostManager:
         Raises:
             Exception: If the file cannot be created
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         tmp_file = tempfile.NamedTemporaryFile()
         with open(tmp_file.name, 'w+') as tmp:
@@ -365,14 +413,15 @@ class HostManager:
             raise Exception(f"Error creating file {path} on host {host}: {result}")
         return result
 
-    def control_service(self, host, service, state, become=False, ignore_errors=False):
+    def control_service(self, host, service, state, become=None, ignore_errors=False):
         """Control a service on a host.
 
             Args:
                 host (str): Hostname
                 service (str): Service name
                 state (str): Service state
-                become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
                 ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
             Returns:
@@ -381,6 +430,12 @@ class HostManager:
             Raises:
                 Exception: If the service cannot be controlled
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         ansible_command = 'win_service' if self.get_host_variables(host)['os_name'] == 'windows' else 'service'
 
@@ -391,13 +446,14 @@ class HostManager:
 
         return result
 
-    def run_command(self, host, cmd, become=False, ignore_errors=False):
+    def run_command(self, host, cmd, become=None, ignore_errors=False):
         """Run a command on a host.
 
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -406,6 +462,12 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         ansible_command = 'win_command' if self.get_host_variables(host)['os_name'] == 'windows' else 'command'
 
@@ -417,14 +479,15 @@ class HostManager:
 
         return rc, stdout
 
-    def run_shell(self, host, cmd, become=False, ignore_errors=False):
+    def run_shell(self, host, cmd, become=None, ignore_errors=False):
         """Run a shell command on a host.
         The difference with run_command is that here, shell symbols like &, |, etc. are interpreted.
 
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -433,6 +496,12 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
         rc = None
         stdout = None
@@ -448,7 +517,7 @@ class HostManager:
 
         return rc, stdout
 
-    def find_files(self, host, path, pattern, recurse=False, use_regex=False, become=False, ignore_errors=False):
+    def find_files(self, host, path, pattern, recurse=False, use_regex=False, become=None, ignore_errors=False):
         """Search and return information of a file inside a path.
 
         Args:
@@ -457,7 +526,8 @@ class HostManager:
             pattern (str): Restrict the files to be returned to those whose basenames match the pattern specified.
             recurse (bool): If target is a directory, recursively descend into the directory looking for files.
             use_regex (bool): If no, the patterns are file globs (shell), if yes, they are python regexes.
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -466,6 +536,12 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         test_infra_host = self.get_host(host)
         ansible_command = 'win_find' if self.get_host_variables(host)['os_name'] == 'windows' else 'find'
         ansible_pattern_arguments = 'patterns' if self.get_host_variables(host)['os_name'] == 'windows' else 'pattern'
@@ -479,13 +555,14 @@ class HostManager:
 
         return result['files']
 
-    def get_file_stats(self, host, path, become=False, ignore_errors=False):
+    def get_file_stats(self, host, path, become=None, ignore_errors=False):
         """Retrieve file or file system status.
 
         Args:
             host (str): Hostname.
             path (str): The full path of the file/object to get the facts of.
-            become (bool, optional): Use sudo. Defaults to False.
+            become (bool): If no value is provided, it will take from the inventory. If there is no value, 
+                           it will default to False.
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -494,6 +571,12 @@ class HostManager:
         Raises:
             Exception: If the command cannot be run.
         """
+        if become is None:
+            become = self.get_host_variables(host)['become'].get('become', False)
+
+            if become in ['', None]:
+                become = False
+
         testinfra_host = self.get_host(host)
 
         if self.get_host_variables(host)['os_name'] == 'windows':
@@ -507,3 +590,4 @@ class HostManager:
             raise Exception(f"Error getting stats of {path} on host {host}: {result}")
 
         return result
+

--- a/src/wazuh_qa_framework/system/host_manager.py
+++ b/src/wazuh_qa_framework/system/host_manager.py
@@ -159,7 +159,8 @@ class HostManager:
             src_path (str): Source path
             dest_path (str): Destination path
             remote_src (bool): If True, the file is assumed to live on the remote machine, not the controller.
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -188,7 +189,8 @@ class HostManager:
         Args:
             host (str): Hostname
             path (str): File path
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool): Ignore errors
 
         Returns:
@@ -216,7 +218,8 @@ class HostManager:
             host (str): Hostname
             dest_path (str): Destination path
             filesystem (dict): File structure
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -256,7 +259,8 @@ class HostManager:
             host (str): Hostname
             file_path (str): File path
             recreate (bool, optional): Recreate file. Defaults to True.
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -288,7 +292,8 @@ class HostManager:
         Args:
             host (str): Hostname
             file_path (str): File path
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -315,7 +320,8 @@ class HostManager:
             host (str): Hostname
             path (str): path for the file to create and modify
             content (str, bytes): content to write into the file
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -348,7 +354,8 @@ class HostManager:
             owner (str): owner of the file
             group (str): group of the file
             mode (str): mode of the file
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -385,7 +392,8 @@ class HostManager:
                 host (str): Hostname
                 service (str): Service name
                 state (str): Service state
-                become (bool): If no value is provided, it will take from the inventory.
+                become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+                provide a value, it will default to False. Defaults None
                 ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
             Returns:
@@ -412,7 +420,8 @@ class HostManager:
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -441,7 +450,8 @@ class HostManager:
         Args:
             host (str): Hostname
             cmd (str): Command to run
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -476,7 +486,8 @@ class HostManager:
             pattern (str): Restrict the files to be returned to those whose basenames match the pattern specified.
             recurse (bool): If target is a directory, recursively descend into the directory looking for files.
             use_regex (bool): If no, the patterns are file globs (shell), if yes, they are python regexes.
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:
@@ -506,7 +517,8 @@ class HostManager:
         Args:
             host (str): Hostname.
             path (str): The full path of the file/object to get the facts of.
-            become (bool): If no value is provided, it will take from the inventory.
+            become (bool): If no value is provided, it will be taken from the inventory. If the inventory does not
+            provide a value, it will default to False. Defaults None
             ignore_errors (bool, optional): Ignore errors. Defaults to False.
 
         Returns:


### PR DESCRIPTION
|Related issue|
|-------------|
| #38      |

## Description

This PR aims to add change HostManager methods using Os information from inventory.yml instead of paraters.

### Updated
#### Methods that have changes in the parameterization of Os and/or become:

- check_connection()
- copy_file()
- truncate_file()
- remove_file()
- create_file()
- control_service()
- run_command()
- run_shell()
- find_files()
- get_file_stats()

#### Methods that have changes in the parameterization of become:
- get_file_content()
- modify_file_content()
- synchronize_linux_directory()


## Testing performed

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
|  @pro-akim (Developer)  |         |  | [:green_circle:](https://github.com/wazuh/qa-system-framework/files/11654450/report.zip) | Windows - Agent  | https://github.com/wazuh/qa-system-framework/pull/40/commits/9a4eb261691f5db512fd43b589d3fc44e8564959 | |


