### PR TITLE
Add configuration methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
 system_tests_launcher = [
     'ansible>=4.10.0',
     'pytest-testinfra>=6.7.0',
-    'pytest==7.3.1'
+    'pytest==7.3.1',
+    'pywinrm>=0.2.2'
 ]
 unit_testing = [
     'pytest >= 6.2.5',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ system_tests_launcher = [
     'ansible>=4.10.0',
     'pytest-testinfra>=6.7.0',
     'pytest==7.3.1',
-    'pywinrm>=0.2.2'
+    'pywinrm>=0.2.2',
     'ansible_runner>=2.3.2'
 ]
 unit_testing = [

--- a/src/wazuh_qa_framework/generic_modules/tools/configuration.py
+++ b/src/wazuh_qa_framework/generic_modules/tools/configuration.py
@@ -1,0 +1,222 @@
+import xml.etree.ElementTree as ET
+from typing import List
+
+
+unlimited_sections = ['localfile', 'command', 'active-response']
+
+
+# customize _serialize_xml to avoid lexicographical order in XML attributes
+def _serialize_xml(write, elem, qnames, namespaces,
+                   short_empty_elements, **kwargs):
+    tag = elem.tag
+    text = elem.text
+    if tag is ET.Comment:
+        write("<!--%s-->" % text)
+    elif tag is ET.ProcessingInstruction:
+        write("<?%s?>" % text)
+    else:
+        tag = qnames[tag]
+        if tag is None:
+            if text:
+                write(ET._escape_cdata(text))
+            for e in elem:
+                _serialize_xml(write, e, qnames, None,
+                               short_empty_elements=short_empty_elements)
+        else:
+            write("<" + tag)
+            items = list(elem.items())
+            if items or namespaces:
+                if namespaces:
+                    for v, k in sorted(namespaces.items(),
+                                       key=lambda x: x[1]):  # sort on prefix
+                        if k:
+                            k = ":" + k
+                        write(" xmlns%s=\"%s\"" % (
+                            k,
+                            ET._escape_attrib(v)
+                        ))
+                for k, v in items:  # avoid lexicographical order for XML attributes
+                    if isinstance(k, ET.QName):
+                        k = k.text
+                    if isinstance(v, ET.QName):
+                        v = qnames[v.text]
+                    else:
+                        v = ET._escape_attrib(v)
+                    write(" %s=\"%s\"" % (qnames[k], v))
+            if text or len(elem) or not short_empty_elements:
+                write(">")
+                if text:
+                    write(ET._escape_cdata(text))
+                for e in elem:
+                    _serialize_xml(write, e, qnames, None,
+                                   short_empty_elements=short_empty_elements)
+                write("</" + tag + ">")
+            else:
+                write(" />")
+    if elem.tail:
+        write(ET._escape_cdata(elem.tail))
+
+
+def set_section_wazuh_conf(sections, template=None):
+    """
+    Set a configuration in a section of Wazuh. It replaces the content if it exists.
+
+    Args:
+        sections (list): List of dicts with section and new elements
+        section (str, optional): Section of Wazuh configuration to replace. Default `'syscheck'`
+        new_elements (list, optional) : List with dictionaries for settings elements in the section. Default `None`
+        template (list of string, optional): File content template
+
+    Returns:
+        List of str: List of str with the custom Wazuh configuration.
+    """
+
+    def create_elements(section: ET.Element, elements: List):
+        """
+        Insert new elements in a Wazuh configuration section.
+
+        Args:
+            section (ET.Element): Section where the element will be inserted.
+            elements (list): List with the new elements to be inserted.
+        Returns:
+            ET.ElementTree: Modified Wazuh configuration.
+        """
+        tag = None
+        for element in elements:
+            for tag_name, properties in element.items():
+                tag = ET.SubElement(section, tag_name)
+                new_elements = properties.get('elements')
+                attributes = properties.get('attributes')
+                if attributes is not None:
+                    for attribute in attributes:
+                        if isinstance(attribute, dict):  # noqa: E501
+                            for attr_name, attr_value in attribute.items():
+                                tag.attrib[attr_name] = str(attr_value)
+                if new_elements:
+                    create_elements(tag, new_elements)
+                else:
+                    tag.text = str(properties.get('value'))
+                    attributes = properties.get('attributes')
+                    if attributes:
+                        for attribute in attributes:
+                            if attribute is not None and isinstance(attribute, dict):  # noqa: E501
+                                for attr_name, attr_value in attribute.items():
+                                    tag.attrib[attr_name] = str(attr_value)
+                tag.tail = "\n    "
+        tag.tail = "\n  "
+
+    def purge_multiple_root_elements(str_list: List[str], root_delimeter: str = "</ossec_config>") -> List[str]:
+        """
+        Remove from the list all the lines located after the root element ends.
+
+        This operation is needed before attempting to convert the list to ElementTree because if the ossec.conf had more
+        than one `<ossec_config>` element as root the conversion would fail.
+
+        Args:
+            str_list (list or str): The content of the ossec.conf file in a list of str.
+            root_delimeter (str, optional: The expected string to identify when the first root element ends,
+            by default "</ossec_config>"
+
+        Returns:
+            list of str : The first N lines of the specified str_list until the root_delimeter is found. The rest of
+            the list will be ignored.
+        """
+        line_counter = 0
+        for line in str_list:
+            line_counter += 1
+            if root_delimeter in line:
+                return str_list[0:line_counter]
+        else:
+            return str_list
+
+    def to_elementTree(str_list: List[str], root_delimeter: str = "</ossec_config>") -> ET.ElementTree:
+        """
+        Turn a list of str into an ElementTree object.
+
+        As ElementTree does not support xml with more than one root element this function will parse the list first with
+        `purge_multiple_root_elements` to ensure there is only one root element.
+
+        Args:
+            str_list (list of str): A list of strings with every line of the ossec conf.
+
+        Returns:
+            ElementTree: A ElementTree object with the data of the `str_list`
+        """
+        str_list = purge_multiple_root_elements(str_list, root_delimeter)
+        return ET.ElementTree(ET.fromstringlist(str_list))
+
+    def to_str_list(elementTree: ET.ElementTree) -> List[str]:
+        """
+        Turn an ElementTree object into a list of str.
+
+        Args:
+            elementTree (ElementTree): A ElementTree object with all the data of the ossec.conf.
+
+        Returns:
+            (list of str): A list of str containing all the lines of the ossec.conf.
+        """
+        return ET.tostringlist(elementTree.getroot(), encoding="unicode")
+
+    def find_module_config(wazuh_conf: ET.ElementTree, section: str, attributes: List[dict]) -> ET.ElementTree:
+        r"""
+        Check if a certain configuration section exists in ossec.conf and returns the corresponding block if exists.
+        (This extra function has been necessary to implement it to configure the wodle blocks, since they have the same
+        section but different attributes).
+
+        Args:
+            wazuh_conf (ElementTree): An ElementTree object with all the data of the ossec.conf
+            section (str): Name of the tag or configuration section to search for. For example: vulnerability_detector
+            attributes (list of dict): List with section attributes. Needed to check if the section exists with all the
+            searched attributes and values. For example (wodle section) [{'name': 'syscollector'}]
+        Returns:
+            ElementTree: An ElementTree object with the section data found in ossec.conf. None if nothing was found.
+        """
+        if attributes is None:
+            return wazuh_conf.find(section)
+        else:
+            attributes_query = ''.join([f"[@{attribute}='{value}']" for index, _ in enumerate(attributes)
+                                        for attribute, value in attributes[index].items()])
+            query = f"{section}{attributes_query}"
+
+            try:
+                return wazuh_conf.find(query)
+            except AttributeError:
+                return None
+
+    # Generate a ElementTree representation of the previous list to work with its sections
+    root_delimeter = '</agent_config>' if '<agent_config>' in template else '</ossec_config>'
+    wazuh_conf = to_elementTree(template, root_delimeter)
+    for section in sections:
+        attributes = section.get('attributes')
+        section_conf = find_module_config(wazuh_conf, section['section'], attributes)
+        # Create section if it does not exist, clean otherwise
+        if not section_conf:
+            section_conf = ET.SubElement(wazuh_conf.getroot(), section['section'])
+            section_conf.text = '\n    '
+            section_conf.tail = '\n\n  '
+        else:
+            # Add section if there is no limit
+            if section_conf.tag in unlimited_sections:
+                section_conf = ET.SubElement(wazuh_conf.getroot(), section['section'])
+                section_conf.text = '\n    '
+                section_conf.tail = '\n\n  '
+            else:
+                prev_text = section_conf.text
+                prev_tail = section_conf.tail
+                section_conf.clear()
+                section_conf.text = prev_text
+                section_conf.tail = prev_tail
+
+        # Insert section attributes
+        if attributes:
+            for attribute in attributes:
+                if attribute is not None and isinstance(attribute, dict):  # noqa: E501
+                    for attr_name, attr_value in attribute.items():
+                        section_conf.attrib[attr_name] = str(attr_value)
+
+        # Insert elements
+        new_elements = section.get('elements', list())
+        if new_elements:
+            create_elements(section_conf, new_elements)
+
+    return to_str_list(wazuh_conf)

--- a/src/wazuh_qa_framework/generic_modules/tools/configuration.py
+++ b/src/wazuh_qa_framework/generic_modules/tools/configuration.py
@@ -4,6 +4,7 @@ from typing import List
 
 
 unlimited_sections = ['localfile', 'command', 'active-response']
+xml_configuration_files = ['ossec.conf', 'agent.conf']
 
 
 # customize _serialize_xml to avoid lexicographical order in XML attributes

--- a/src/wazuh_qa_framework/generic_modules/tools/configuration.py
+++ b/src/wazuh_qa_framework/generic_modules/tools/configuration.py
@@ -131,7 +131,7 @@ def set_section_wazuh_conf(sections, template=None):
         else:
             return str_list
 
-    def to_elementTree(str_list: List[str], root_delimeter: str = "</ossec_config>") -> ET.ElementTree:
+    def to_element_tree(str_list: List[str], root_delimeter: str = "</ossec_config>") -> ET.ElementTree:
         """
         Turn a list of str into an ElementTree object.
 
@@ -187,7 +187,7 @@ def set_section_wazuh_conf(sections, template=None):
 
     # Generate a ElementTree representation of the previous list to work with its sections
     root_delimeter = '</agent_config>' if '<agent_config>' in template else '</ossec_config>'
-    wazuh_conf = to_elementTree(template, root_delimeter)
+    wazuh_conf = to_element_tree(template, root_delimeter)
     for section in sections:
         attributes = section.get('attributes')
         section_conf = find_module_config(wazuh_conf, section['section'], attributes)

--- a/src/wazuh_qa_framework/generic_modules/tools/configuration.py
+++ b/src/wazuh_qa_framework/generic_modules/tools/configuration.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+import yaml
 from typing import List
 
 
@@ -220,3 +221,28 @@ def set_section_wazuh_conf(sections, template=None):
             create_elements(section_conf, new_elements)
 
     return to_str_list(wazuh_conf)
+
+
+def configure_local_internal_options(new_conf):
+    local_internal_configuration_string = ''
+    for option_name, option_value in new_conf.items():
+        local_internal_configuration_string += f"{str(option_name)}={str(option_value)}\n"
+    return local_internal_configuration_string
+
+
+def configure_ossec_conf(new_conf, template):
+    new_configuration = ''.join(set_section_wazuh_conf(new_conf, template))
+    return new_configuration
+
+
+def configure_api_yaml(new_conf):
+    new_configuration = yaml.dump(new_conf)
+    return new_configuration
+
+
+conf_functions = {
+    'local_internal_options.conf': configure_local_internal_options,
+    'ossec.conf': configure_ossec_conf,
+    'agent.conf': configure_ossec_conf,
+    'api.yaml': configure_api_yaml
+}

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -14,13 +14,13 @@ from wazuh_qa_framework.system.host_manager import HostManager
 
 DEFAULT_INSTALL_PATH = {
     'linux': '/var/ossec',
-    'windows': 'C:\\Program Files\\ossec-agent',
+    'windows': 'C:/Program Files (x86)/ossec-agent',
     'darwin': '/Library/Ossec'
 }
 
 DEFAULT_TEMPORAL_DIRECTORY = {
     'linux': '/tmp',
-    'windows': 'C:\\Users\\qa\\AppData\Local\Temp'
+    'windows': 'C:/Users/qa/AppData/Local/Temp'
 }
 
 
@@ -561,7 +561,7 @@ class WazuhEnvironmentHandler(HostManager):
                        src_path=backup_file, remote_src=True, become=not self.is_windows(host))
         self.logger.debug(f"Restored {dest_file} backup on {host} succesfully")
 
-    def restore_environment_backup_configuration(self, backup_configurations, parallel=False):
+    def restore_environment_backup_configuration(self, backup_configurations, parallel=True):
         """Restore environment backup configuration
 
         Args:

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -7,7 +7,7 @@ import yaml
 from multiprocessing.pool import ThreadPool
 
 from wazuh_qa_framework.generic_modules.logging.base_logger import BaseLogger
-from wazuh_qa_framework.generic_modules.tools.configuration import conf_functions
+from wazuh_qa_framework.generic_modules.tools.configuration import conf_functions, xml_configuration_files
 from wazuh_qa_framework.global_variables.daemons import WAZUH_ANGENT_WINDOWS_SERVICE_NAME
 from wazuh_qa_framework.system.host_manager import HostManager
 
@@ -382,7 +382,7 @@ class WazuhEnvironmentHandler(HostManager):
         parameters = {'new_conf': configuration_values}
 
         # Get template for ossec.conf and agent.conf
-        if configuration_file == 'ossec.conf' or configuration_file == 'agent.conf':
+        if configuration_file in xml_configuration_files:
             current_configuration = self.get_file_content(host, host_configuration_file_path, become=True)
             parameters.update({'template': current_configuration})
 

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -468,7 +468,8 @@ class WazuhEnvironmentHandler(HostManager):
         """Backup specified files in host
 
         Args:
-            configuration_list (dict): Host configuration files to backup
+            host (str): Hostname to backup
+            file (str): File to backup
         Returns:
             dict: Host backup filepaths
         """
@@ -476,7 +477,7 @@ class WazuhEnvironmentHandler(HostManager):
         backup_paths = {host: {}}
         host_configuration_file_path = self.get_file_fullpath(host, file, group)
         temporal_folder = DEFAULT_TEMPORAL_DIRECTORY[self.get_ansible_host_os(host)]
-        backup_file = os.path.join(temporal_folder, file + '.backup',)
+        backup_file = os.path.join(temporal_folder, file + '.backup')
         backup_paths[host][host_configuration_file_path] = backup_file
 
         self.copy_file(host, host_configuration_file_path, backup_file, remote_src=True,
@@ -489,7 +490,7 @@ class WazuhEnvironmentHandler(HostManager):
         """Backup specified files in all hosts
 
         Args:
-            configuration_list (dict): Host configuration files to backup
+            configuration_hosts(dict): Host configuration files to backup
         Returns:
             dict: Host backup filepaths
         """
@@ -525,7 +526,8 @@ class WazuhEnvironmentHandler(HostManager):
         """Restore backup configuration
 
         Args:
-            backup_configuration (dict): Backup configuration filepaths
+            host (str): Hostname to restore
+            dest_file (str): File to restore
         """
         self.logger.debug(f"Restoring {dest_file} backup on {host}")
         self.copy_file(host=host, dest_path=dest_file,
@@ -536,7 +538,7 @@ class WazuhEnvironmentHandler(HostManager):
         """Restore environment backup configuration
 
         Args:
-            backup_configuration (dict): Backup configuration filepaths
+            backup_configurations (dict): Backup configuration filepaths
         """
         self.logger.info('Restoring backup')
         if parallel:

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -353,26 +353,13 @@ class WazuhEnvironmentHandler(HostManager):
         - local_internal_options configuration should be provided as a map
         - api.yaml should be provided as a map
 
-        Example:
-            local_internal_options:
-                remoted.debug: 2
-                wazuh_modulesd.debug: 2
-            ossec.conf:
-                - 'section': 'client',
-                  'elements':
-                  - 'server':
-                        'elements':
-                            - 'address':
-                                'value': 121.1.3.1
-            agent.conf:
-                - 'group': 'default',
-                - configuration:
-                    - 'section': 'client',
-                      'elements':
-                        - 'server':
-                            'elements':
-                                - 'address':
-                                    'value': 121.1.3.1
+        Examples:
+            - [('manager1', 'local_internal_options.conf', {'remoted.debug': '2'})]
+            - [('manager1', 'ossec.conf', [{'section': 'client', 'elements': [{'server': {'elements': [{'address':
+               {'value': '121.1.3.1'}}]}}]}])]
+            - [('manager1', 'agent.conf', {'group': 'default', 'configuration':
+               [{'section': 'client', 'elements': [{'server': {'elements': [{'address': {'value': '121.1.3.1'}}]}}]}]})]
+            - [('manager1', 'api.yaml', {'logs': {'level': 'debug'}})]
         Args:
             host (str): Hostname
             configuration_file (str): File name to be configured
@@ -409,20 +396,29 @@ class WazuhEnvironmentHandler(HostManager):
     def configure_environment(self, configuration_hosts, parallel=True):
         """Configure multiple hosts at the same time.
         Example:
-        wazuh-agent1:
-            local_internal_options:
-                remoted.debug: 2
-                wazuh_modulesd.debug: 2
+        wazuh-manager1:
+            local_internal_options.conf:
+              remoted.debug: '2'
             ossec.conf:
-                - 'section': 'client',
-                  'elements':
-                  - 'server':
-                        'elements':
-                            - 'address':
-                                'value': 121.1.3.1
-            api.yml:
-                ....
-        wazuh-agent2:
+            - section: client
+              elements:
+              - server:
+                  elements:
+                  - address:
+                      value: 121.1.3.1
+            agent.conf:
+              group: default
+              configuration:
+              - section: client
+                elements:
+                - server:
+                    elements:
+                    - address:
+                        value: 121.1.3.1
+            api.yaml:
+              logs:
+                level: debug
+        wazuh-agent1:
             ossec.conf:
                 ...
         Args:

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -4,11 +4,10 @@
 
 import os
 import yaml
-import xml.etree.ElementTree as ET
 from multiprocessing.pool import ThreadPool
-from typing import List
 
 from wazuh_qa_framework.generic_modules.logging.base_logger import BaseLogger
+from wazuh_qa_framework.generic_modules.tools.configuration import set_section_wazuh_conf
 from wazuh_qa_framework.global_variables.daemons import WAZUH_ANGENT_WINDOWS_SERVICE_NAME
 from wazuh_qa_framework.system.host_manager import HostManager
 
@@ -23,6 +22,7 @@ DEFAULT_TEMPORAL_DIRECTORY = {
     'linux': '/tmp',
     'windows': 'C:\\Users\\qa\\AppData\Local\Temp'
 }
+
 
 def configure_local_internal_options(new_conf):
     local_internal_configuration_string = ''
@@ -980,162 +980,3 @@ class WazuhEnvironmentHandler(HostManager):
             bool: True if host is manager
         """
         return host in self.get_managers()
-
-
-def set_section_wazuh_conf(sections, template=None):
-    """
-    Set a configuration in a section of Wazuh. It replaces the content if it exists.
-
-    Args:
-        sections (list): List of dicts with section and new elements
-        section (str, optional): Section of Wazuh configuration to replace. Default `'syscheck'`
-        new_elements (list, optional) : List with dictionaries for settings elements in the section. Default `None`
-        template (list of string, optional): File content template
-
-    Returns:
-        List of str: List of str with the custom Wazuh configuration.
-    """
-
-    def create_elements(section: ET.Element, elements: List):
-        """
-        Insert new elements in a Wazuh configuration section.
-
-        Args:
-            section (ET.Element): Section where the element will be inserted.
-            elements (list): List with the new elements to be inserted.
-        Returns:
-            ET.ElementTree: Modified Wazuh configuration.
-        """
-        tag = None
-        for element in elements:
-            for tag_name, properties in element.items():
-                tag = ET.SubElement(section, tag_name)
-                new_elements = properties.get('elements')
-                attributes = properties.get('attributes')
-                if attributes is not None:
-                    for attribute in attributes:
-                        if isinstance(attribute, dict):  # noqa: E501
-                            for attr_name, attr_value in attribute.items():
-                                tag.attrib[attr_name] = str(attr_value)
-                if new_elements:
-                    create_elements(tag, new_elements)
-                else:
-                    tag.text = str(properties.get('value'))
-                    attributes = properties.get('attributes')
-                    if attributes:
-                        for attribute in attributes:
-                            if attribute is not None and isinstance(attribute, dict):  # noqa: E501
-                                for attr_name, attr_value in attribute.items():
-                                    tag.attrib[attr_name] = str(attr_value)
-                tag.tail = "\n    "
-        tag.tail = "\n  "
-
-    def purge_multiple_root_elements(str_list: List[str], root_delimeter: str = "</ossec_config>") -> List[str]:
-        """
-        Remove from the list all the lines located after the root element ends.
-
-        This operation is needed before attempting to convert the list to ElementTree because if the ossec.conf had more
-        than one `<ossec_config>` element as root the conversion would fail.
-
-        Args:
-            str_list (list or str): The content of the ossec.conf file in a list of str.
-            root_delimeter (str, optional: The expected string to identify when the first root element ends,
-            by default "</ossec_config>"
-
-        Returns:
-            list of str : The first N lines of the specified str_list until the root_delimeter is found. The rest of
-            the list will be ignored.
-        """
-        line_counter = 0
-        for line in str_list:
-            line_counter += 1
-            if root_delimeter in line:
-                return str_list[0:line_counter]
-        else:
-            return str_list
-
-    def to_elementTree(str_list: List[str], root_delimeter: str = "</ossec_config>") -> ET.ElementTree:
-        """
-        Turn a list of str into an ElementTree object.
-
-        As ElementTree does not support xml with more than one root element this function will parse the list first with
-        `purge_multiple_root_elements` to ensure there is only one root element.
-
-        Args:
-            str_list (list of str): A list of strings with every line of the ossec conf.
-
-        Returns:
-            ElementTree: A ElementTree object with the data of the `str_list`
-        """
-        str_list = purge_multiple_root_elements(str_list, root_delimeter)
-        return ET.ElementTree(ET.fromstringlist(str_list))
-
-    def to_str_list(elementTree: ET.ElementTree) -> List[str]:
-        """
-        Turn an ElementTree object into a list of str.
-
-        Args:
-            elementTree (ElementTree): A ElementTree object with all the data of the ossec.conf.
-
-        Returns:
-            (list of str): A list of str containing all the lines of the ossec.conf.
-        """
-        return ET.tostringlist(elementTree.getroot(), encoding="unicode")
-
-    def find_module_config(wazuh_conf: ET.ElementTree, section: str, attributes: List[dict]) -> ET.ElementTree:
-        r"""
-        Check if a certain configuration section exists in ossec.conf and returns the corresponding block if exists.
-        (This extra function has been necessary to implement it to configure the wodle blocks, since they have the same
-        section but different attributes).
-
-        Args:
-            wazuh_conf (ElementTree): An ElementTree object with all the data of the ossec.conf
-            section (str): Name of the tag or configuration section to search for. For example: vulnerability_detector
-            attributes (list of dict): List with section attributes. Needed to check if the section exists with all the
-            searched attributes and values. For example (wodle section) [{'name': 'syscollector'}]
-        Returns:
-            ElementTree: An ElementTree object with the section data found in ossec.conf. None if nothing was found.
-        """
-        if attributes is None:
-            return wazuh_conf.find(section)
-        else:
-            attributes_query = ''.join([f"[@{attribute}='{value}']" for index, _ in enumerate(attributes)
-                                        for attribute, value in attributes[index].items()])
-            query = f"{section}{attributes_query}"
-
-            try:
-                return wazuh_conf.find(query)
-            except AttributeError:
-                return None
-
-    # Generate a ElementTree representation of the previous list to work with its sections
-    root_delimeter = '</agent_config>' if '<agent_config>' in template else '</ossec_config>'
-    wazuh_conf = to_elementTree(purge_multiple_root_elements(template, root_delimeter), root_delimeter)
-    for section in sections:
-        attributes = section.get('attributes')
-        section_conf = find_module_config(wazuh_conf, section['section'], attributes)
-        # Create section if it does not exist, clean otherwise
-        if not section_conf:
-            section_conf = ET.SubElement(wazuh_conf.getroot(), section['section'])
-            section_conf.text = '\n    '
-            section_conf.tail = '\n\n  '
-        else:
-            prev_text = section_conf.text
-            prev_tail = section_conf.tail
-            section_conf.clear()
-            section_conf.text = prev_text
-            section_conf.tail = prev_tail
-
-        # Insert section attributes
-        if attributes:
-            for attribute in attributes:
-                if attribute is not None and isinstance(attribute, dict):  # noqa: E501
-                    for attr_name, attr_value in attribute.items():
-                        section_conf.attrib[attr_name] = str(attr_value)
-
-        # Insert elements
-        new_elements = section.get('elements', list())
-        if new_elements:
-            create_elements(section_conf, new_elements)
-
-    return to_str_list(wazuh_conf)

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -7,7 +7,7 @@ import yaml
 from multiprocessing.pool import ThreadPool
 
 from wazuh_qa_framework.generic_modules.logging.base_logger import BaseLogger
-from wazuh_qa_framework.generic_modules.tools.configuration import set_section_wazuh_conf
+from wazuh_qa_framework.generic_modules.tools.configuration import conf_functions
 from wazuh_qa_framework.global_variables.daemons import WAZUH_ANGENT_WINDOWS_SERVICE_NAME
 from wazuh_qa_framework.system.host_manager import HostManager
 
@@ -21,31 +21,6 @@ DEFAULT_INSTALL_PATH = {
 DEFAULT_TEMPORAL_DIRECTORY = {
     'linux': '/tmp',
     'windows': 'C:/Users/qa/AppData/Local/Temp'
-}
-
-
-def configure_local_internal_options(new_conf):
-    local_internal_configuration_string = ''
-    for option_name, option_value in new_conf.items():
-        local_internal_configuration_string += f"{str(option_name)}={str(option_value)}\n"
-    return local_internal_configuration_string
-
-
-def configure_ossec_conf(new_conf, template):
-    new_configuration = ''.join(set_section_wazuh_conf(new_conf, template))
-    return new_configuration
-
-
-def configure_api_yaml(new_conf):
-    new_configuration = yaml.dump(new_conf)
-    return new_configuration
-
-
-conf_functions = {
-    'local_internal_options.conf': configure_local_internal_options,
-    'ossec.conf': configure_ossec_conf,
-    'agent.conf': configure_ossec_conf,
-    'api.yaml': configure_api_yaml
 }
 
 


### PR DESCRIPTION
## Description

In this PR, functions have been added that will be used for the configuration of Wazuh nodes. This configuration can be done either in parallel or not.

The following functions have been added which are responsible for modifying and restoring the configuration:

- `configure_host()`.
- `change_agents_configured_manager()`.
- `backup_host_configuration()`.
- `restore_host_backup_configuration()`

In addition, the following functions have been added, which are responsible for executing the above functions in parallel when desired:

- `configure_environment()`.
- `backup_environment_configuration()`.
- `restore_environment_backup_configuration()`.

The configuration expected by these functions will have the following format:

```
wazuh-manager1:
  local_internal_options.conf:
    remoted.debug: '2'
  ossec.conf:
  - section: client
    elements:
    - server:
        elements:
        - address:
            value: 121.1.3.1
  agent.conf:
    group: default
    configuration:
    - section: client
      elements:
      - server:
          elements:
          - address:
              value: 121.1.3.1
  api.yaml:
    logs:
      level: debug

wazuh-agent1:
  ossec.conf:
    ...
```

The supported files are `ossec.conf`, `agent.conf`, `api.yaml` and `agent.conf`