### PR TITLE
Add function to get master and worker nodes

### DIFF
--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -769,7 +769,22 @@ class WazuhEnvironmentHandler(HostManager):
         Returns:
             str: Manager master node
         """
-        pass
+        for manager in self.get_managers():
+            if self.get_host_variables(manager)['type'] == 'master':
+                master_node = manager
+        return master_node
+
+    def get_worker_nodes(self):
+        """Get worker managers' hostnames
+
+        Returns:
+            list: Manager worker nodes
+        """
+        worker_nodes = []
+        for manager in self.get_managers():
+            if self.get_host_variables(manager)['type'] == 'worker':
+                worker_nodes.append(manager)
+        return worker_nodes
 
     def get_api_details(self):
         """Get api details

--- a/src/wazuh_qa_framework/system/wazuh_handler.py
+++ b/src/wazuh_qa_framework/system/wazuh_handler.py
@@ -786,6 +786,17 @@ class WazuhEnvironmentHandler(HostManager):
                 worker_nodes.append(manager)
         return worker_nodes
 
+    def get_node_type(self, host):
+        """Get manager type
+
+        Returns:
+            str: Manager node type
+        """
+        if self.is_manager(host):
+            return 'master' if host == self.get_master_node() else 'worker'
+        else:
+            raise ValueError(f'Host {host} is not a manager')
+
     def get_api_details(self):
         """Get api details
 


### PR DESCRIPTION
## Description

The following functions have been implemented in this RP:

- `get_master_node()`: returns the master node.
- `get_worker_nodes()`: returns a list of worker nodes
- `get_node_type()`: returns node type

As the deployer used for these tests does not support more than one master (although in the future there could be environments with several masters), it has been assumed that there can only be one master node.

Also, it is not necessary to check if the environment is a cluster or not to obtain the master node, since if it is a single-node, it is also a master.