### PR TITLE
Add manager and agent roles

### DIFF
--- a/provisioning/playbooks/ansible.cfg
+++ b/provisioning/playbooks/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+hash_behaviour=merge

--- a/provisioning/playbooks/wazuh-agent.yml
+++ b/provisioning/playbooks/wazuh-agent.yml
@@ -1,0 +1,4 @@
+---
+- hosts: agent
+  roles:
+    - ../roles/wazuh/agent

--- a/provisioning/playbooks/wazuh-manager.yml
+++ b/provisioning/playbooks/wazuh-manager.yml
@@ -1,0 +1,4 @@
+---
+- hosts: manager
+  roles:
+    - role: ../roles/wazuh/manager

--- a/provisioning/playbooks/wazuh-manager.yml
+++ b/provisioning/playbooks/wazuh-manager.yml
@@ -1,4 +1,5 @@
 ---
 - hosts: manager
+  become: true
   roles:
     - role: ../roles/wazuh/manager

--- a/provisioning/roles/wazuh/agent/defaults/main.yml
+++ b/provisioning/roles/wazuh/agent/defaults/main.yml
@@ -4,9 +4,9 @@ wazuh_path: "{{ ('/var/ossec' if (ansible_os_family != 'Windows' and ansible_os_
 agent_conf_path: "{{ ('/var/ossec/etc/ossec.conf' if (ansible_os_family != 'Windows' and ansible_os_family != 'Darwin')) or (wazuh_winagent_config.conf_path if (ansible_os_family == 'Windows')) or ('/Library/Ossec/etc/ossec.conf' if (ansible_os_family == 'Darwin')) }}"
 
 # Custom packages installation
-
 wazuh_custom_packages_installation_agent_enabled: false
 
+# Win configuration
 wazuh_winagent_config:
   download_dir: C:\
   install_dir: C:\Program Files\ossec-agent\
@@ -16,6 +16,6 @@ wazuh_winagent_config:
   # Adding quotes to auth_path_x86 since win_shell outputs error otherwise
   auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
 
-wazuh_winagent_config_url: https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi
-wazuh_winagent_package_name: wazuh-agent-{{ wazuh_agent_version }}-1.msi
+wazuh_winagent_config_url: "{{ wazuh_custom_packages_installation_agent_msi_url | default(wazuh_winagent_repo_pkg_url) }}"
+wazuh_winagent_package_name: "{{ wazuh_winagent_package_name_generic | default(wazuh_winagent_repo_pkg_name)}}"
 wazuh_winagent_package_name_generic: wazuh-agent.msi

--- a/provisioning/roles/wazuh/agent/defaults/main.yml
+++ b/provisioning/roles/wazuh/agent/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+wazuh_agent_version: "{{ packages_version | default(agent_production_version) }}"
+wazuh_path: "{{ ('/var/ossec' if (ansible_os_family != 'Windows' and ansible_os_family != 'Darwin')) or (wazuh_winagent_config.install_dir if (ansible_os_family == 'Windows')) or ('/Library/Ossec' if (ansible_os_family == 'Darwin')) }}"
+agent_conf_path: "{{ ('/var/ossec/etc/ossec.conf' if (ansible_os_family != 'Windows' and ansible_os_family != 'Darwin')) or (wazuh_winagent_config.conf_path if (ansible_os_family == 'Windows')) or ('/Library/Ossec/etc/ossec.conf' if (ansible_os_family == 'Darwin')) }}"
+
+# Custom packages installation
+
+wazuh_custom_packages_installation_agent_enabled: false
+
+wazuh_winagent_config:
+  download_dir: C:\
+  install_dir: C:\Program Files\ossec-agent\
+  install_dir_x86: C:\Program Files (x86)\ossec-agent\
+  conf_path: C:\Program Files (x86)\ossec-agent\ossec.conf
+  auth_path: C:\Program Files\ossec-agent\agent-auth.exe
+  # Adding quotes to auth_path_x86 since win_shell outputs error otherwise
+  auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
+
+wazuh_winagent_config_url: https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi
+wazuh_winagent_package_name: wazuh-agent-{{ wazuh_agent_version }}-1.msi
+wazuh_winagent_package_name_generic: wazuh-agent.msi

--- a/provisioning/roles/wazuh/agent/handlers/main.yml
+++ b/provisioning/roles/wazuh/agent/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: start WazuhSvc
+  win_service: name=WazuhSvc start_mode=auto state=started
+  when: ansible_os_family == "Windows"
+
+- name: start service
+  become: true
+  command: '"{{ wazuh_path }}"/bin/wazuh-control start'
+  when: ansible_os_family != "Windows"

--- a/provisioning/roles/wazuh/agent/meta/main.yml
+++ b/provisioning/roles/wazuh/agent/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: Wazuh
+  description: Installing, deploying and configuring Wazuh Agent.
+  company: wazuh.com
+  license: license (GPLv3)
+  min_ansible_version: 2.0
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+  galaxy_tags:
+    - monitoring
+dependencies: []

--- a/provisioning/roles/wazuh/agent/tasks/Debian.yml
+++ b/provisioning/roles/wazuh/agent/tasks/Debian.yml
@@ -1,0 +1,74 @@
+---
+- name: Debian/Ubuntu | Install ca-certificates and gnupg
+  become: true
+  apt:
+    name:
+      - ca-certificates
+      - gnupg
+    state: present
+  register: wazuh_agent_ca_package_install
+  until: wazuh_agent_ca_package_install is succeeded
+
+- name: Debian/Ubuntu | Install apt-transport-https and acl
+  become: true
+  apt:
+    name:
+      - apt-transport-https
+      - acl
+    state: present
+  register: wazuh_agent_ca_package_install
+  until: wazuh_agent_ca_package_install is succeeded
+  when: not (ansible_distribution == "Debian" and ansible_distribution_major_version in ['11'])
+
+- name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
+  become: true
+  shell: |
+    set -o pipefail
+    curl -s {{ wazuh_repo.gpg }} | apt-key add -
+  args:
+    warn: false
+    executable: /bin/bash
+  changed_when: false
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int == 14
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Debian/Ubuntu | Installing Wazuh repository key
+  become: true
+  apt_key:
+    url: "{{ wazuh_repo.gpg }}"
+    id: "{{ wazuh_repo.key_id }}"
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Debian/Ubuntu | Add Wazuh repositories
+  become: true
+  apt_repository:
+    filename: wazuh_repo
+    repo: "{{ wazuh_repo.apt }}"
+    state: present
+    update_cache: true
+  when:
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Linux Debian | Install wazuh-agent
+  become: true
+  apt:
+    name: "wazuh-agent={{ wazuh_agent_version }}-*"
+    state: present
+    cache_valid_time: 3600
+  when:
+    - ansible_os_family|lower != "redhat"
+    - not wazuh_custom_packages_installation_agent_enabled
+    - not ansible_check_mode
+  tags:
+    - init
+
+- name: Remove Wazuh repository (and clean up left-over metadata)
+  become: true
+  apt_repository:
+    repo: "{{ wazuh_repo.apt }}"
+    state: absent
+  changed_when: false

--- a/provisioning/roles/wazuh/agent/tasks/Linux.yml
+++ b/provisioning/roles/wazuh/agent/tasks/Linux.yml
@@ -1,0 +1,7 @@
+---
+- name: Include tasks based on OS
+  include_tasks: "{{ ansible_os_family }}.yml"
+
+- include_tasks: "installation_from_custom_packages.yml"
+  when:
+    - wazuh_custom_packages_installation_agent_enabled

--- a/provisioning/roles/wazuh/agent/tasks/MacOS.yml
+++ b/provisioning/roles/wazuh/agent/tasks/MacOS.yml
@@ -1,0 +1,8 @@
+- name: Download agent package
+  get_url:
+    url: "{{ wazuh_custom_packages_installation_agent_macos_url }}"
+    dest: /Users/vagrant
+    validate_certs: no
+
+- include_tasks: "installation_from_custom_packages.yml"
+  when: wazuh_custom_packages_installation_agent_enabled

--- a/provisioning/roles/wazuh/agent/tasks/RedHat.yml
+++ b/provisioning/roles/wazuh/agent/tasks/RedHat.yml
@@ -1,0 +1,46 @@
+---
+- name: RedHat/CentOS 5 | Install Wazuh repo
+  yum_repository:
+    name: wazuh_repo
+    description: Wazuh repository
+    baseurl: "{{ wazuh_repo.yum }}5/"
+    gpgkey: "{{ wazuh_repo.gpg }}-5"
+    gpgcheck: true
+  changed_when: false
+  when:
+    - (ansible_facts['os_family']|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
+    - (ansible_distribution_major_version|int <= 5)
+    - not wazuh_custom_packages_installation_agent_enabled
+  register: repo_v5_installed
+
+- name: RedHat/CentOS/Fedora | Install Wazuh repo
+  become: true
+  yum_repository:
+    name: wazuh_repo
+    description: Wazuh repository
+    baseurl: "{{ wazuh_repo.yum }}"
+    gpgkey: "{{ wazuh_repo.gpg }}"
+    gpgcheck: true
+  changed_when: false
+  when:
+    - repo_v5_installed is skipped
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Linux CentOS/RedHat | Install wazuh-agent
+  become: true
+  yum:
+    name: wazuh-agent-{{ wazuh_agent_version }}
+    state: present
+    lock_timeout: '{{ wazuh_agent_yum_lock_timeout }}'
+  when:
+    - ansible_os_family|lower == "redhat"
+    - not wazuh_custom_packages_installation_agent_enabled
+  tags:
+    - init
+
+- name: Remove Wazuh repository (and clean up left-over metadata)
+  become: true
+  yum_repository:
+    name: wazuh_repo
+    state: absent
+  changed_when: false

--- a/provisioning/roles/wazuh/agent/tasks/Solaris.yml
+++ b/provisioning/roles/wazuh/agent/tasks/Solaris.yml
@@ -1,0 +1,16 @@
+- name: Download Solaris 11 agent package
+  get_url:
+    url: "{{ wazuh_custom_packages_installation_agent_solaris_11_url }}"
+    dest: /export/home/vagrant
+    validate_certs: no
+  when: wazuh_custom_packages_installation_agent_solaris_11_url is defined
+
+- name: Download Solaris 10 agent package
+  get_url:
+    url: "{{ wazuh_custom_packages_installation_agent_solaris_10_url }}"
+    dest: /export/home/vagrant
+    validate_certs: no
+  when: wazuh_custom_packages_installation_agent_solaris_10_url is defined
+
+- include_tasks: "installation_from_custom_packages.yml"
+  when: wazuh_custom_packages_installation_agent_enabled

--- a/provisioning/roles/wazuh/agent/tasks/Windows.yml
+++ b/provisioning/roles/wazuh/agent/tasks/Windows.yml
@@ -18,37 +18,17 @@
   when:
     - not check_path.stat.exists
 
-- name: Windows | Check if Wazuh installer is already downloaded
-  win_stat:
-    path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
-  register: wazuh_package_downloaded
-
 - name: Windows | Download Wazuh Agent package
   win_get_url:
     url: "{{ wazuh_winagent_config_url }}"
-    dest: "{{ wazuh_winagent_config.download_dir }}"
-  when:
-    - not wazuh_package_downloaded.stat.exists
-    - not wazuh_custom_packages_installation_agent_enabled
+    dest: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
 
 - name: Windows | Install Agent if not already installed
   win_package:
     path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
     state: present
-  when: not wazuh_custom_packages_installation_agent_enabled
-
-- name: Windows | Check if client.keys exists
-  win_stat:
-    path: "{{ wazuh_agent_win_path }}client.keys"
-  register: check_windows_key
-  tags:
-    - config
 
 - name: Windows | Delete downloaded Wazuh agent installer file
   win_file:
     path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
     state: absent
-
-- include_tasks: "installation_from_custom_packages.yml"
-  when:
-    - wazuh_custom_packages_installation_agent_enabled

--- a/provisioning/roles/wazuh/agent/tasks/Windows.yml
+++ b/provisioning/roles/wazuh/agent/tasks/Windows.yml
@@ -1,0 +1,54 @@
+---
+- name: Windows | Check if Program Files (x86) exists
+  win_stat:
+    path: C:\Program Files (x86)
+  register: check_path
+
+- name: Windows | Set Win Path (x86)
+  set_fact:
+    wazuh_agent_win_path: "{{ wazuh_winagent_config.install_dir_x86 }}"
+    wazuh_agent_win_auth_path: "{{ wazuh_winagent_config.auth_path_x86 }}"
+  when:
+    - check_path.stat.exists
+
+- name: Windows | Set Win Path (x64)
+  set_fact:
+    wazuh_agent_win_path: "{{ wazuh_winagent_config.install_dir }}"
+    wazuh_agent_win_auth_path: "{{ wazuh_winagent_config.auth_path }}"
+  when:
+    - not check_path.stat.exists
+
+- name: Windows | Check if Wazuh installer is already downloaded
+  win_stat:
+    path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
+  register: wazuh_package_downloaded
+
+- name: Windows | Download Wazuh Agent package
+  win_get_url:
+    url: "{{ wazuh_winagent_config_url }}"
+    dest: "{{ wazuh_winagent_config.download_dir }}"
+  when:
+    - not wazuh_package_downloaded.stat.exists
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Windows | Install Agent if not already installed
+  win_package:
+    path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
+    state: present
+  when: not wazuh_custom_packages_installation_agent_enabled
+
+- name: Windows | Check if client.keys exists
+  win_stat:
+    path: "{{ wazuh_agent_win_path }}client.keys"
+  register: check_windows_key
+  tags:
+    - config
+
+- name: Windows | Delete downloaded Wazuh agent installer file
+  win_file:
+    path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
+    state: absent
+
+- include_tasks: "installation_from_custom_packages.yml"
+  when:
+    - wazuh_custom_packages_installation_agent_enabled

--- a/provisioning/roles/wazuh/agent/tasks/installation_from_custom_packages.yml
+++ b/provisioning/roles/wazuh/agent/tasks/installation_from_custom_packages.yml
@@ -63,18 +63,3 @@
     when:
       - ansible_os_family == 'Solaris'
       - wazuh_custom_packages_installation_agent_solaris_11_url is defined
-
-# Windows
-  - name: Donwload Windows agent msi
-    win_get_url:
-      url: "{{ wazuh_custom_packages_installation_agent_msi_url }}"
-      dest: "{{wazuh_winagent_config.download_dir}}{{wazuh_winagent_package_name_generic}}"
-    when:
-      - ansible_os_family == "Windows"
-
-  - name: Install Wazuh Agent from .msi packages | custom win_package
-    win_package:
-      path: "{{wazuh_winagent_config.download_dir}}{{wazuh_winagent_package_name_generic}}"
-      state: present
-    when:
-      - ansible_os_family == "Windows"

--- a/provisioning/roles/wazuh/agent/tasks/installation_from_custom_packages.yml
+++ b/provisioning/roles/wazuh/agent/tasks/installation_from_custom_packages.yml
@@ -1,0 +1,80 @@
+---
+  - name: Install Wazuh Agent from .deb packages
+    become: true
+    apt:
+      deb: "{{ wazuh_custom_packages_installation_agent_deb_url }}"
+      state: present
+    when:
+      - ansible_os_family|lower == "debian"
+      - wazuh_custom_packages_installation_agent_enabled
+
+  - name: Install Wazuh Agent from .rpm packages | yum
+    become: true
+    yum:
+      name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
+      state: present
+    when:
+      - ansible_os_family|lower == "redhat"
+      - wazuh_custom_packages_installation_agent_enabled
+      - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
+      - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+
+  - name: Install Wazuh Agent from .rpm packages | dnf
+    become: true
+    dnf:
+      name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
+      state: present
+      disable_gpg_check: True
+
+    when:
+      - ansible_os_family|lower == "redhat"
+      - wazuh_custom_packages_installation_agent_enabled
+      - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
+        (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+
+# MacOS
+
+  - name: Install MacOS agent from pkg | custom macos pkg
+    become: true
+    shell: installer -pkg wazuh-* -target /
+    args:
+      chdir: /Users/vagrant
+    when: ansible_os_family == "Darwin"
+
+# Solaris
+  - name: Install Solaris 10 wazuh agent custom package
+    become: true
+    shell: pkgadd -d wazuh*
+    environment:
+      PATH: "/opt/python3/bin/:/usr/sbin:/usr/bin:/usr/sbin/:/opt/csw/gnu/:/usr/sfw/bin/:/opt/csw/bin/"
+    args:
+      chdir: "/export/home/vagrant"
+    when:
+      - ansible_os_family == 'Solaris'
+      - wazuh_custom_packages_installation_agent_solaris_10_url is defined
+
+  - name: Install Solaris 11 wazuh agent custom package
+    become: true
+    shell: pkg install -g wazuh* wazuh-agent
+    environment:
+      PATH: "/opt/python3/bin/:/usr/sbin:/usr/bin:/usr/sbin/:/opt/csw/gnu/:/usr/sfw/bin/:/opt/csw/bin/"
+    args:
+      chdir: "/export/home/vagrant"
+    when:
+      - ansible_os_family == 'Solaris'
+      - wazuh_custom_packages_installation_agent_solaris_11_url is defined
+
+# Windows
+  - name: Donwload Windows agent msi
+    win_get_url:
+      url: "{{ wazuh_custom_packages_installation_agent_msi_url }}"
+      dest: "{{wazuh_winagent_config.download_dir}}{{wazuh_winagent_package_name_generic}}"
+    when:
+      - ansible_os_family == "Windows"
+
+  - name: Install Wazuh Agent from .msi packages | custom win_package
+    win_package:
+      path: "{{wazuh_winagent_config.download_dir}}{{wazuh_winagent_package_name_generic}}"
+      state: present
+    when:
+      - ansible_os_family == "Windows"

--- a/provisioning/roles/wazuh/agent/tasks/main.yml
+++ b/provisioning/roles/wazuh/agent/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+
+- include_vars: ../../vars/repo_vars.yml
+
+- include_vars: ../../vars/repo.yml
+  when: packages_repository == 'production'
+
+- include_vars: ../../vars/repo_pre-release.yml
+  when: packages_repository == 'pre-release'
+
+- include_vars: ../../vars/repo_staging.yml
+  when: packages_repository == 'staging'
+
+- include_tasks: "Windows.yml"
+  when: ansible_os_family == "Windows"
+
+- include_tasks: "Linux.yml"
+  when: ansible_system == "Linux"
+
+- include_tasks: "MacOS.yml"
+  when: ansible_system == "Darwin"
+
+- include_tasks: "Solaris.yml"
+  when: ansible_os_family == "Solaris"
+
+- block:
+  - name: Add the manager's IP to the agent's ossec.conf
+    become: true
+    replace:
+      path: "{{ agent_conf_path }}"
+      regexp: '<address>.*</address>'
+      replace: "<address>{{ manager_ip }}</address>"
+    notify: start service
+    when: ansible_os_family != "Windows"
+
+  - name: Add the manager's IP to the winagent's ossec.conf
+    community.windows.win_lineinfile:
+      path: "{{ agent_conf_path }}"
+      regex: '<address>.*</address>'
+      line: "<address>{{ manager_ip }}</address>"
+    notify: start WazuhSvc
+    when: ansible_os_family == "Windows"
+
+- name: run the handlers after the installation
+  meta: flush_handlers

--- a/provisioning/roles/wazuh/manager/defaults/main.yml
+++ b/provisioning/roles/wazuh/manager/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+## Global
+wazuh_manager_version: "{{ packages_version | default(manager_production_version) }}"
+wazuh_dir: "/var/ossec"
+service_name: wazuh-manager
+wazuh_manager_config_defaults:
+  repo: '{{ wazuh_repo }}'
+
+
+# Custom packages installation
+wazuh_custom_packages_installation_manager_enabled: false
+wazuh_custom_packages_installation_manager_deb_url: "https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/"
+wazuh_custom_packages_installation_manager_rpm_url: "https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/"

--- a/provisioning/roles/wazuh/manager/handlers/main.yml
+++ b/provisioning/roles/wazuh/manager/handlers/main.yml
@@ -1,8 +1,3 @@
 ---
 - name: start service
-  become: true
-  systemd:
-    name: "{{ service_name }}"
-    daemon_reload: true
-    state: started
-    enabled: true
+  ansible.builtin.command: /var/ossec/bin/wazuh-control start

--- a/provisioning/roles/wazuh/manager/handlers/main.yml
+++ b/provisioning/roles/wazuh/manager/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: start service
+  become: true
+  systemd:
+    name: "{{ service_name }}"
+    daemon_reload: true
+    state: started
+    enabled: true

--- a/provisioning/roles/wazuh/manager/meta/main.yml
+++ b/provisioning/roles/wazuh/manager/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: Wazuh
+  description: Installing, deploying and configuring Wazuh Manager.
+  company: wazuh.com
+  license: license (GPLv3)
+  min_ansible_version: 2.0
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+  galaxy_tags:
+    - monitoring
+dependencies: []

--- a/provisioning/roles/wazuh/manager/tasks/Debian.yml
+++ b/provisioning/roles/wazuh/manager/tasks/Debian.yml
@@ -1,6 +1,5 @@
 ---
 - name: Debian/Ubuntu | Install gnupg, apt-transport-https
-  become: true
   apt:
     name:
       - gnupg
@@ -12,7 +11,6 @@
   until: wazuh_manager_https_packages_installed is succeeded
 
 - name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
-  become: true
   shell: |
     set -o pipefail
     curl -s {{ wazuh_repo.gpg }} | apt-key add -
@@ -44,7 +42,6 @@
     - not wazuh_custom_packages_installation_manager_enabled
 
 - name: Debian/Ubuntu | Install wazuh-manager
-  become: true  
   apt:
     name: "wazuh-manager={{ wazuh_manager_version }}-*"
     state: present
@@ -52,7 +49,6 @@
   when: not wazuh_custom_packages_installation_manager_enabled
 
 - name: Install Wazuh Manager from .deb packages
-  become: true
   apt:
     deb: "{{ wazuh_custom_packages_installation_manager_deb_url }}"
     state: present

--- a/provisioning/roles/wazuh/manager/tasks/Debian.yml
+++ b/provisioning/roles/wazuh/manager/tasks/Debian.yml
@@ -1,0 +1,64 @@
+---
+- name: Debian/Ubuntu | Install gnupg, apt-transport-https
+  become: true
+  apt:
+    name:
+      - gnupg
+      - apt-transport-https
+    state: present
+    cache_valid_time: 3600
+    install_recommends: false
+  register: wazuh_manager_https_packages_installed
+  until: wazuh_manager_https_packages_installed is succeeded
+
+- name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
+  become: true
+  shell: |
+    set -o pipefail
+    curl -s {{ wazuh_repo.gpg }} | apt-key add -
+  args:
+    warn: false
+    executable: /bin/bash
+  changed_when: false
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int == 14
+    - not wazuh_custom_packages_installation_manager_enabled
+
+- name: Debian/Ubuntu | Installing Wazuh repository key
+  apt_key:
+    url: "{{ wazuh_repo.gpg }}"
+    id: "{{ wazuh_repo.key_id }}"
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not wazuh_custom_packages_installation_manager_enabled
+
+- name: Debian/Ubuntu | Add Wazuh repositories
+  apt_repository:
+    filename: wazuh_repo
+    repo: "{{ wazuh_repo.apt }}"
+    state: present
+    update_cache: true
+  changed_when: false
+  when:
+    - not wazuh_custom_packages_installation_manager_enabled
+
+- name: Debian/Ubuntu | Install wazuh-manager
+  become: true  
+  apt:
+    name: "wazuh-manager={{ wazuh_manager_version }}-*"
+    state: present
+  notify: start service
+  when: not wazuh_custom_packages_installation_manager_enabled
+
+- name: Install Wazuh Manager from .deb packages
+  become: true
+  apt:
+    deb: "{{ wazuh_custom_packages_installation_manager_deb_url }}"
+    state: present
+  notify: start service
+  when:
+    - wazuh_custom_packages_installation_manager_enabled
+
+- name: run the handlers after the installation
+  meta: flush_handlers

--- a/provisioning/roles/wazuh/manager/tasks/RedHat.yml
+++ b/provisioning/roles/wazuh/manager/tasks/RedHat.yml
@@ -1,0 +1,68 @@
+---
+- name: RedHat/CentOS 5 | Install Wazuh repo
+  become: true
+  yum_repository:
+    name: wazuh_repo
+    description: Wazuh repository
+    baseurl: "{{ wazuh_repo.yum }}5/"
+    gpgkey: "{{ wazuh_repo.gpg }}-5"
+    gpgcheck: true
+  changed_when: false
+  when:
+    - (ansible_os_family|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
+    - (ansible_distribution_major_version|int <= 5)
+    - not wazuh_custom_packages_installation_manager_enabled
+  register: repo_v5_manager_installed
+
+- name: RedHat/CentOS/Fedora | Install Wazuh repo
+  become: true
+  yum_repository:
+    name: wazuh_repo
+    description: Wazuh repository
+    baseurl: "{{ wazuh_repo.yum }}"
+    gpgkey: "{{ wazuh_repo.gpg }}"
+    gpgcheck: true
+  changed_when: false
+  when:
+    - repo_v5_manager_installed is skipped
+    - not wazuh_custom_packages_installation_manager_enabled
+
+- name: CentOS/RedHat/Amazon | Install wazuh-manager
+  become: true
+  package:
+    name: "wazuh-manager-{{ wazuh_manager_version }}"
+    state: present
+  register: wazuh_manager_main_packages_installed
+  until: wazuh_manager_main_packages_installed is succeeded
+  when:
+    - ansible_os_family|lower == "redhat"
+    - not wazuh_custom_packages_installation_manager_enabled
+  notify: start service
+  tags:
+    - init
+
+- block:
+  - name: Install Wazuh Manager from .rpm packages | yum
+    become: true
+    yum:
+      name: "{{ wazuh_custom_packages_installation_manager_rpm_url }}"
+      state: present
+    when:
+      - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
+      - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+
+  - name: Install Wazuh Manager from .rpm packages | dnf
+    become: true
+    dnf:
+      name: "{{ wazuh_custom_packages_installation_manager_rpm_url }}"
+      state: present
+      disable_gpg_check: True
+    when:
+      - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
+        (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+  notify: start service
+  when:
+    - wazuh_custom_packages_installation_manager_enabled
+
+- name: run the handlers after the installation
+  meta: flush_handlers

--- a/provisioning/roles/wazuh/manager/tasks/RedHat.yml
+++ b/provisioning/roles/wazuh/manager/tasks/RedHat.yml
@@ -43,16 +43,15 @@
 
 - block:
   - name: Install Wazuh Manager from .rpm packages | yum
-    become: true
     yum:
       name: "{{ wazuh_custom_packages_installation_manager_rpm_url }}"
       state: present
+    notify: start service
     when:
       - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
       - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
 
   - name: Install Wazuh Manager from .rpm packages | dnf
-    become: true
     dnf:
       name: "{{ wazuh_custom_packages_installation_manager_rpm_url }}"
       state: present

--- a/provisioning/roles/wazuh/manager/tasks/main.yml
+++ b/provisioning/roles/wazuh/manager/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Include vars/repo_vars.yml
+  include_vars: ../../vars/repo_vars.yml
+
+- name: Include vars/repo.yml
+  include_vars: ../../vars/repo.yml
+  when: packages_repository == 'production'
+
+- name: Include vars/repo_pre-release.yml
+  include_vars: ../../vars/repo_pre-release.yml
+  when: packages_repository == 'pre-release'
+
+- name: Include vars/repo_staging.yml
+  include_vars: ../../vars/repo_staging.yml
+  when: packages_repository == 'staging'
+
+- name: Include tasks based on OS
+  include_tasks: "{{ ansible_os_family }}.yml"
+
+- name: Ensure Wazuh Manager service is started and enabled.
+  service:
+    name: "wazuh-manager"
+    enabled: true
+    state: started
+  tags:
+    - config

--- a/provisioning/roles/wazuh/manager/tasks/main.yml
+++ b/provisioning/roles/wazuh/manager/tasks/main.yml
@@ -18,10 +18,3 @@
 - name: Include tasks based on OS
   include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: Ensure Wazuh Manager service is started and enabled.
-  service:
-    name: "wazuh-manager"
-    enabled: true
-    state: started
-  tags:
-    - config

--- a/provisioning/roles/wazuh/vars/repo.yml
+++ b/provisioning/roles/wazuh/vars/repo.yml
@@ -1,0 +1,12 @@
+wazuh_repo:
+  apt: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
+  yum: 'https://packages.wazuh.com/4.x/yum/'
+  gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
+  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+
+certs_gen_tool_version: 4.4
+
+# Url of certificates generator tool
+certs_gen_tool_url: "https://packages.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/provisioning/roles/wazuh/vars/repo.yml
+++ b/provisioning/roles/wazuh/vars/repo.yml
@@ -3,10 +3,5 @@ wazuh_repo:
   yum: 'https://packages.wazuh.com/4.x/yum/'
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
-wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-
-certs_gen_tool_version: 4.4
-
-# Url of certificates generator tool
-certs_gen_tool_url: "https://packages.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"
+wazuh_winagent_repo_pkg_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+wazuh_winagent_repo_pkg_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"

--- a/provisioning/roles/wazuh/vars/repo_pre-release.yml
+++ b/provisioning/roles/wazuh/vars/repo_pre-release.yml
@@ -1,0 +1,12 @@
+wazuh_repo:
+  apt: 'deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main'
+  yum: 'https://packages-dev.wazuh.com/pre-release/yum/'
+  gpg: 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
+  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+wazuh_winagent_config_url: "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+
+certs_gen_tool_version: 4.4
+
+# Url of certificates generator tool
+certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/provisioning/roles/wazuh/vars/repo_pre-release.yml
+++ b/provisioning/roles/wazuh/vars/repo_pre-release.yml
@@ -4,9 +4,4 @@ wazuh_repo:
   gpg: 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-
-certs_gen_tool_version: 4.4
-
-# Url of certificates generator tool
-certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"
+wazuh_winagent_package_name: "wazuh-agent-1.msi"

--- a/provisioning/roles/wazuh/vars/repo_staging.yml
+++ b/provisioning/roles/wazuh/vars/repo_staging.yml
@@ -1,0 +1,12 @@
+wazuh_repo:
+  apt: 'deb https://packages-dev.wazuh.com/staging/apt/ unstable main'
+  yum: 'https://packages-dev.wazuh.com/staging/yum/'
+  gpg: 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
+  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+wazuh_winagent_config_url: "https://packages-dev.wazuh.com/staging/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+
+certs_gen_tool_version: 4.4
+
+# Url of certificates generator tool
+certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/provisioning/roles/wazuh/vars/repo_staging.yml
+++ b/provisioning/roles/wazuh/vars/repo_staging.yml
@@ -4,9 +4,4 @@ wazuh_repo:
   gpg: 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/staging/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-
-certs_gen_tool_version: 4.4
-
-# Url of certificates generator tool
-certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"
+wazuh_winagent_package_name: "wazuh-agent-1.msi"

--- a/provisioning/roles/wazuh/vars/repo_vars.yml
+++ b/provisioning/roles/wazuh/vars/repo_vars.yml
@@ -1,2 +1,3 @@
 packages_repository: production
 manager_production_version: 4.4.4
+agent_production_version: 4.4.4

--- a/provisioning/roles/wazuh/vars/repo_vars.yml
+++ b/provisioning/roles/wazuh/vars/repo_vars.yml
@@ -1,0 +1,2 @@
+packages_repository: production
+manager_production_version: 4.4.4


### PR DESCRIPTION
## Description

This PR adds a first roles structure to the framework within a new folder, `provisioning`.

### OS support:

- Manager
    - CentOS
    - Ubuntu
    - Debian
    - ALAS
    - RedHat
- Agent
    - CentOS
    - Ubuntu
    - Debian
    - ALAS
    - RedHat
    - Windows
    - Solaris (only providing custom package)
    - MacOS (only providing custom package)

The installed version is the latest from production by default. If you provide another one using `packages_version` it installs that version using the repo.

You can enable the custom packages by setting `wazuh_custom_packages_installation_agent_enabled` to true using the inventory and providing the package url.

### Add

- Add provisioning folder structure
- Add manager role
    - installation via repo which also supports versioning
    - installation via custom packages
- Add agent role
    - installation via repo which also supports versioning
    - installation via custom packages
